### PR TITLE
Fix transactional update types

### DIFF
--- a/lib/interfaces/model.interface.ts
+++ b/lib/interfaces/model.interface.ts
@@ -408,20 +408,20 @@ export interface DeleteTransaction<Key> {
 }
 export interface UpdateTransaction<Key, Data> {
   (obj: Data): UpdateTransactionResult;
-  (keyObj: Key, updateObj: Partial<Data>): UpdateTransactionResult;
+  (keyObj: Key, updateObj: UpdatePartial<Data>): UpdateTransactionResult;
   (
     keyObj: Key,
-    updateObj: Partial<Data>,
+    updateObj: UpdatePartial<Data>,
     settings: ModelUpdateSettings & { return: 'document' },
   ): UpdateTransactionResult;
   (
     keyObj: Key,
-    updateObj: Partial<Data>,
+    updateObj: UpdatePartial<Data>,
     settings: ModelUpdateSettings & { return: 'request' },
   ): UpdateTransactionResult;
   (
     keyObj: Key,
-    updateObj?: Partial<Data>,
+    updateObj?: UpdatePartial<Data>,
     settings?: ModelUpdateSettings,
   ): UpdateTransactionResult;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the following block of code fails type checking because `transaction.update()` uses `Partial<Data>` rather than `UpdatePartial<Data>`.

```ts
await dynamoose.transaction([
  this.userModel.transaction.update(
    { id: userId },
    { $ADD: { balance: 100 } },
  ),
  this.anotherModel.transaction.update(
    { id: userId },
    { $ADD: { balance: 100 } },
  ),
]);
```

## What is the new behavior?

This PR modifies `transaction.update()` to accept an update of type `UpdatePartial<Data>` instead of type `Partial<Data>`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```