### PR TITLE
Add session token

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ interface DynamooseModuleOptions {
   aws?: {
     accessKeyId?: string;
     secretAccessKey?: string;
+    sessionToken?: string;
     region?: string;
   };
   local?: boolean | string;

--- a/lib/interfaces/dynamoose-options.interface.ts
+++ b/lib/interfaces/dynamoose-options.interface.ts
@@ -7,6 +7,7 @@ export interface DynamooseModuleOptions {
   aws?: {
     accessKeyId?: string;
     secretAccessKey?: string;
+    sessionToken?: string;
     region?: string;
   };
   local?: boolean | string;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "nestjs-dynamoose",
-  "version": "0.4.0",
+  "name": "cbumstead-nestjs-dynamoose",
+  "version": "0.4.1",
   "description": "Nest - modern, fast, powerful node.js web framework (@dynamoose)",
   "author": "Hardys",
-  "repository": "https://github.com/hardyscc/nestjs-dynamoose.git",
+  "repository": "https://github.com/cbumstead/nestjs-dynamoose",
   "license": "MIT",
   "scripts": {
     "lint": "eslint \"lib/**/*.ts\" --max-warnings 0",


### PR DESCRIPTION
This PR adds sessionToken to aws options

`export interface DynamooseModuleOptions {
  aws?: {
    accessKeyId?: string;
    secretAccessKey?: string;
    sessionToken?: string;
    region?: string;
  };
  local?: boolean | string;
  ddb?: DynamoDB;
  model?: ModelOptionsOptional;
  logger?: boolean | LoggerService;
};`