### PR TITLE
fix(model): Keep actual model names

### DIFF
--- a/lib/dynamoose.providers.ts
+++ b/lib/dynamoose.providers.ts
@@ -44,12 +44,10 @@ export function createDynamooseAsyncProviders(
         } else {
           schema = object as ModelDefinition['schema'];
         }
-        const tableName =
-          modelDefinition?.tableName || model.tableName || model.name;
         const options: ModelTableOptions = modelDefinition?.options || model.options || {};
         const serializers = modelDefinition?.serializers || model.serializers;
 
-        options.tableName = tableName
+        options.tableName = model.tableName || model.name
 
         const modelInstance = dynamoose.model(model.name, schema, options);
         if (serializers) {

--- a/lib/dynamoose.providers.ts
+++ b/lib/dynamoose.providers.ts
@@ -1,5 +1,6 @@
 import { flatten } from '@nestjs/common';
 import * as dynamoose from 'dynamoose';
+import { ModelTableOptions } from 'dynamoose/dist/Model'
 import { getModelToken } from './common/dynamoose.utils';
 import { DYNAMOOSE_INITIALIZATION } from './dynamoose.constants';
 import { ModelDefinition } from './interfaces';
@@ -10,7 +11,7 @@ export function createDynamooseProviders(models: ModelDefinition[] = []) {
     provide: getModelToken(model.name),
     useFactory: () => {
       const modelInstance = dynamoose.model(
-        model.tableName || model.name,
+        model.name,
         model.schema,
         model.options,
       );
@@ -45,10 +46,12 @@ export function createDynamooseAsyncProviders(
         }
         const tableName =
           modelDefinition?.tableName || model.tableName || model.name;
-        const options = modelDefinition?.options || model.options;
+        const options: ModelTableOptions = modelDefinition?.options || model.options || {};
         const serializers = modelDefinition?.serializers || model.serializers;
 
-        const modelInstance = dynamoose.model(tableName, schema, options);
+        options.tableName = tableName
+
+        const modelInstance = dynamoose.model(model.name, schema, options);
         if (serializers) {
           Object.entries(serializers).forEach(([key, value]) => {
             modelInstance.serializer.add(key, value);

--- a/lib/interfaces/model-definition.interface.ts
+++ b/lib/interfaces/model-definition.interface.ts
@@ -1,11 +1,10 @@
 import { Schema, SchemaDefinition } from 'dynamoose/dist/Schema';
 import { SerializerOptions } from 'dynamoose/dist/Serializer';
-import { TableOptionsOptional } from 'dynamoose/dist/Table';
+import { ModelTableOptions } from 'dynamoose/dist/Model'
 
 export type ModelDefinition = {
   name: string;
   schema: Schema | SchemaDefinition | (Schema | SchemaDefinition)[];
-  tableName?: string;
-  options?: TableOptionsOptional;
+  options?: ModelTableOptions;
   serializers?: { [key: string]: SerializerOptions };
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@nestjs/common": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "@nestjs/core": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-    "dynamoose": "^3.0.0",
+    "dynamoose": "^3.2.0",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.0.0 || ^7.0.0"
   },


### PR DESCRIPTION
Needed for the correct operation of a Dynamoose's ModelStore with a single-table design.
This solves the problem when you utilising a single-table design by storing multiple models within the same table.

Since Dynamoose v3.2.0 we can provide the tableName option when creating a model, so the model name can be left unchanged.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When you create two or more models with same tableName, nestjs-dynamoose passes tableName to the dynamoose.model's first argument (model name), so Dynamoose uses that tableName as every model name and cant store all these models in ModelStore.

Issue Number: N/A


## What is the new behavior?
Now the tableName will be passed to the model creation options, and the model name wont be changed, so Dynamoose will be able to operate the ModelStore correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information