### PR TITLE
fix: add consistent setting for batchGet operation

### DIFF
--- a/lib/interfaces/model.interface.ts
+++ b/lib/interfaces/model.interface.ts
@@ -65,6 +65,7 @@ export interface ModelBatchGetItemsResponse<T> extends ItemArray<T> {
 export interface ModelBatchGetSettings {
   return?: 'items' | 'request';
   attributes?: string[];
+  consistent?: boolean;
 }
 export interface ModelBatchDeleteSettings {
   return?: 'response' | 'request';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, we can't use `consistent` setting with the batchGet operation even if it's supported by Dynamoose:
```ts
model.batchGet(
  [{ pk: 'pk', sk: 'pk' }],
  {
    return: 'items',
    consistent: true // <-- Does not exist in the current interface
  }
)
```

## What is the new behavior?

Being able to use the `consistent: true` setting to execute strongly consistent operations.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Ideally we should push the removal of the custom interfaces to use Dynamoose's ones instead. https://github.com/hardyscc/nestjs-dynamoose/issues/76